### PR TITLE
Eliminate thrown exception for async from fs.readFile in private getLines function

### DIFF
--- a/lib/inireadercore.js
+++ b/lib/inireadercore.js
@@ -82,9 +82,10 @@ function getLines(file, cb, async) {
     if (async) {
         fs.readFile(file, function fileReadCb(err, data) {
             if (err) {
-                throw err;
+                cb(err, null);
+            } else {
+                cb(null, splitLines(data));
             }
-            cb(splitLines(data));
         });
     } else {
         data = fs.readFileSync(file);
@@ -229,10 +230,14 @@ IniReaderCore.prototype.load = IniReaderCore.prototype.init = function load(file
     }
     try {
         if (this.async) {
-            getLines(this.file, function parseLines(lines) {
-                this.lines = lines;
-                this.values = this.parseFile();
-                this.emit('fileParse');
+            getLines(this.file, function parseLines(err, lines) {
+                if (err) {
+                    this.emit('error', err);
+                } else {
+                    this.lines = lines;
+                    this.values = this.parseFile();
+                    this.emit('fileParse');
+                }
             }.bind(this), true);
         } else {
             this.lines = getLines(this.file);


### PR DESCRIPTION
When parsing a file that doesn't exist while in async mode, there is an error thrown from getLines that is not properly caught.  This edit passes the error through the callback instead of throwing it, and the callback function then handles it.
